### PR TITLE
supprime doremifasol de Suggests

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -35,7 +35,6 @@ jobs:
         run: |
           install.packages(c("rcmdcheck", "httpuv", "devtools"))
           remotes::install_deps(dependencies = TRUE)
-          remotes::install_github("inseeFrLab/doremifasol")
         shell: Rscript {0}
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "error")

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -54,11 +54,11 @@ jobs:
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v2
         with:
-          name: doremifasol_${PKGVERSION}_r${{ matrix.config.r-version }}.zip
+          name: doremifasolData_${PKGVERSION}_r${{ matrix.config.r-version }}.zip
           path: dist/
       - name: Upload artifacts - source
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v2
         with:
-          name: doremifasol_${PKGVERSION}_r${{ matrix.config.r-version }}.tar.gz
+          name: doremifasolData_${PKGVERSION}_r${{ matrix.config.r-version }}.tar.gz
           path: dist/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,8 +9,7 @@ Authors@R: c(
 Description: Datasets from Insee's Website.
 Language: fr
 Depends: R (>= 3.5.0)
-Suggests: doremifasol, knitr
-Remotes: InseeFrLab/doremifasol
+Suggests: knitr
 License: MIT + file LICENSE
 LazyData: true
 RoxygenNote: 7.1.1


### PR DESCRIPTION
Installer `doremifasol` ainsi que toutes ses dépendances ralentit fortement l'intégration continue.

Comme il n'est d'aucune manière nécessaire au fonctionnement de `doremifasolData` et que le lien de parenté entre les 2 packages est mentionné dans la doc, on peut le retirer de Suggests.